### PR TITLE
Rename tetanus to thanatos

### DIFF
--- a/agent_repos.txt
+++ b/agent_repos.txt
@@ -8,7 +8,7 @@ Agent, MythicAgents/Medusa
 Agent, MythicAgents/merlin
 Agent, MythicAgents/orthrus
 Agent, MythicAgents/poseidon
-Agent, MythicAgents/tetanus
+Agent, MythicAgents/thanatos
 Agent, MythicAgents/typhon
 Agent, MythicAgents/venus
 Agent, MythicAgents/zippy


### PR DESCRIPTION
Changes Tetanus references to Thanatos for the name change